### PR TITLE
update readme

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -11,7 +11,7 @@ Rainbond 文档，包含 Rainbond 5.x 所有文档
 确保您的开发环境有如下软件：
 
 - [Git](http://git-scm.com/)
-- [Node.js](http://nodejs.org/) \>= 14 (with NPM)
+- [Node.js](http://nodejs.org/) \>= 18.0 (with NPM)
 - [Yarn](https://yarnpkg.com/en/docs/install) \>= 1.5
 
 ### 安装

--- a/docs/contribution/code/ui.md
+++ b/docs/contribution/code/ui.md
@@ -10,18 +10,12 @@ git clone https://github.com/goodrain/rainbond-ui.git
 ```
 2. 使用符合要求的 node 版本
 ```
-Node.js 版本  >=  14.15.0
+Node.js 版本  >=  14.15.0  <17
 ```
 
 ## 安装依赖
 
-运行npm安装命令
-
-```
-npm install
-```
-
-或者yarn安装命令
+运行yarn安装命令
 
 ```
 yarn install


### PR DESCRIPTION
文档中的 nodejs >= 14 不对，实际运行会产生以下错误

yarn install 
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
error @docusaurus/core@3.6.0: The engine "node" is incompatible with this module. Expected version ">=18.0". Got "16.14.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

改成 >=18.0